### PR TITLE
fix(core): harden judge evaluation regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-03-24
+
+### Fixed
+
+- Use RubyLLM system instructions instead of the attachment API when calling the judge
+- Roll back invalid global configuration changes when `RubricLLM.configure` validation fails
+- Accept string-keyed batch dataset hashes in sequential and concurrent evaluation
+- Stabilize Student's t-test p-value calculation for small deltas and ordinary sample sizes
+
 ## [0.1.0] - 2026-03-24
 
 ### Added

--- a/lib/rubric_llm.rb
+++ b/lib/rubric_llm.rb
@@ -26,8 +26,10 @@ module RubricLLM
     end
 
     def configure
-      yield(config)
-      config.validate!
+      new_config = Config.new(**config.to_h)
+      yield(new_config)
+      new_config.validate!
+      @config = new_config
     end
 
     def reset_configuration!
@@ -86,6 +88,7 @@ module RubricLLM
     private
 
     def evaluate_sample(evaluator, sample)
+      sample = normalize_sample(sample)
       evaluator.call(
         question: sample[:question],
         answer: sample[:answer],
@@ -121,6 +124,10 @@ module RubricLLM
       return config unless custom_prompt
 
       Config.new(**config.to_h.compact, custom_prompt:)
+    end
+
+    def normalize_sample(sample)
+      sample.transform_keys(&:to_sym)
     end
   end
 end

--- a/lib/rubric_llm/comparison.rb
+++ b/lib/rubric_llm/comparison.rb
@@ -102,40 +102,54 @@ module RubricLLM
       return 0.0 if x <= 0.0
       return 1.0 if x >= 1.0
 
-      ln_beta = Math.lgamma(a)[0] + Math.lgamma(b)[0] - Math.lgamma(a + b)[0]
-      front = Math.exp((a * Math.log(x)) + (b * Math.log(1.0 - x)) - ln_beta) / a
+      ln_beta = Math.lgamma(a + b)[0] - Math.lgamma(a)[0] - Math.lgamma(b)[0]
+      front = Math.exp(ln_beta + (a * Math.log(x)) + (b * Math.log(1.0 - x)))
 
-      # Lentz's continued fraction
+      result = if x < ((a + 1.0) / (a + b + 2.0))
+                 front * beta_continued_fraction(a, b, x) / a
+               else
+                 1.0 - ((front * beta_continued_fraction(b, a, 1.0 - x)) / b)
+               end
+
+      result.clamp(0.0, 1.0)
+    end
+
+    def beta_continued_fraction(a, b, x)
+      tiny = 1e-30
+      qab = a + b
+      qap = a + 1.0
+      qam = a - 1.0
+
       c = 1.0
-      d = 1.0 - ((a + b) * x / (a + 1.0))
-      d = 1.0 if d.abs < 1e-30
+      d = 1.0 - ((qab * x) / qap)
+      d = tiny if d.abs < tiny
       d = 1.0 / d
-      f = d
+      fraction = d
 
       (1..200).each do |m|
-        # Even step
-        numerator = m * (b - m) * x / ((a + (2 * m) - 1) * (a + (2 * m)))
-        d = 1.0 + (numerator * d)
-        d = 1e-30 if d.abs < 1e-30
-        c = 1.0 + (numerator / c)
-        c = 1e-30 if c.abs < 1e-30
-        d = 1.0 / d
-        f *= c * d
+        m2 = 2 * m
 
-        # Odd step
-        numerator = -(a + m) * (a + b + m) * x / ((a + (2 * m)) * (a + (2 * m) + 1))
+        numerator = (m * (b - m) * x) / ((qam + m2) * (a + m2))
         d = 1.0 + (numerator * d)
-        d = 1e-30 if d.abs < 1e-30
+        d = tiny if d.abs < tiny
         c = 1.0 + (numerator / c)
-        c = 1e-30 if c.abs < 1e-30
+        c = tiny if c.abs < tiny
+        d = 1.0 / d
+        fraction *= c * d
+
+        numerator = -((a + m) * (qab + m) * x) / ((a + m2) * (qap + m2))
+        d = 1.0 + (numerator * d)
+        d = tiny if d.abs < tiny
+        c = 1.0 + (numerator / c)
+        c = tiny if c.abs < tiny
         d = 1.0 / d
         delta = c * d
-        f *= delta
+        fraction *= delta
 
-        break if (delta - 1.0).abs < 1e-10
+        break if (delta - 1.0).abs < 1e-12
       end
 
-      front * f
+      fraction
     end
 
     def significance_marker(p)

--- a/lib/rubric_llm/judge.rb
+++ b/lib/rubric_llm/judge.rb
@@ -22,7 +22,8 @@ module RubricLLM
         chat.with_params(max_tokens: config.max_tokens)
 
         full_system_prompt = build_system_prompt(system_prompt)
-        response = chat.ask(user_prompt, with: full_system_prompt)
+        chat.with_instructions(full_system_prompt)
+        response = chat.ask(user_prompt)
         parse_json(response.content)
       rescue StandardError => e
         raise JudgeError, "Judge call failed: #{e.message}" if attempts > config.max_retries

--- a/lib/rubric_llm/version.rb
+++ b/lib/rubric_llm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubricLLM
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/test/test_comparison.rb
+++ b/test/test_comparison.rb
@@ -91,4 +91,10 @@ class TestComparison < Minitest::Test
     assert_in_delta 0.7, result[:mean_b], 0.001
     assert_in_delta 0.15, result[:delta], 0.001
   end
+
+  def test_two_tailed_p_handles_values_close_to_one
+    p_value = @comparison.send(:two_tailed_p, 0.02105086415353341, 72)
+
+    assert_in_delta 0.9832633107858819, p_value, 1e-9
+  end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -149,4 +149,18 @@ class TestConfig < Minitest::Test
       RubricLLM.configure { |c| c.temperature = -5.0 }
     end
   end
+
+  def test_configure_rolls_back_invalid_changes
+    RubricLLM.configure do |c|
+      c.judge_model = "claude-sonnet-4-6"
+      c.temperature = 0.3
+    end
+    original_config = RubricLLM.config.to_h
+
+    assert_raises(RubricLLM::ConfigurationError) do
+      RubricLLM.configure { |c| c.temperature = -5.0 }
+    end
+
+    assert_equal original_config, RubricLLM.config.to_h
+  end
 end

--- a/test/test_evaluator.rb
+++ b/test/test_evaluator.rb
@@ -123,4 +123,21 @@ class TestEvaluator < Minitest::Test
       assert_equal "q#{i + 1}", result.sample[:question]
     end
   end
+
+  def test_evaluate_batch_accepts_string_keyed_samples
+    stub_judge_response('{"score": 0.9, "reasoning": "ok"}')
+    dataset = [
+      { "question" => "q1", "answer" => "a1", "context" => ["c1"], "ground_truth" => "gt1" },
+      { "question" => "q2", "answer" => "a2", "context" => ["c2"], "ground_truth" => "gt2" }
+    ]
+
+    report = RubricLLM.evaluate_batch(dataset, metrics: [RubricLLM::Metrics::Relevance])
+    questions = report.results.map { |result| result.sample[:question] }
+
+    assert_equal 2, report.results.size
+    assert_equal %w[q1 q2], questions
+    report.results.each do |result|
+      assert_in_delta 0.9, result.scores[:relevance]
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ module RubyLLMStub
 
   class FakeChat
     attr_accessor :response_content
-    attr_reader :last_system_prompt, :last_user_prompt, :last_params, :call_count
+    attr_reader :last_system_prompt, :last_user_prompt, :last_params, :last_attachments, :call_count
 
     def initialize(response_content: '{"score": 0.9, "reasoning": "test"}', fail_times: 0, error_class: RuntimeError)
       @response_content = response_content
@@ -29,10 +29,28 @@ module RubyLLMStub
       self
     end
 
+    def with_instructions(instructions, append: false, replace: nil)
+      @last_system_prompt =
+        if append && @last_system_prompt && replace != true
+          "#{@last_system_prompt}\n#{instructions}"
+        else
+          instructions
+        end
+      self
+    end
+
     def ask(prompt, with: nil, **)
       @call_count += 1
       @last_user_prompt = prompt
-      @last_system_prompt = with
+      @last_attachments = with
+
+      Array(with).compact.each do |attachment|
+        next unless attachment.is_a?(String)
+        next if File.exist?(attachment)
+
+        raise Errno::ENOENT, attachment
+      end
+
       raise @error_class, "transient failure" if @call_count <= @fail_times
 
       FakeResponse.new(response_content)

--- a/test/test_judge.rb
+++ b/test/test_judge.rb
@@ -77,6 +77,17 @@ class TestJudge < Minitest::Test
     assert_equal "You are a judge.", chat.last_system_prompt
   end
 
+  def test_call_uses_system_instructions_instead_of_attachments
+    chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}')
+    RubyLLMStub.fake_chat = chat
+
+    judge = RubricLLM::Judge.new(config: RubricLLM.config)
+    judge.call(system_prompt: "You are a judge.", user_prompt: "Evaluate this.")
+
+    assert_nil chat.last_attachments
+    assert_equal "You are a judge.", chat.last_system_prompt
+  end
+
   def test_call_forwards_max_tokens
     chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}')
     RubyLLMStub.fake_chat = chat


### PR DESCRIPTION
## Summary
- fix judge calls to use RubyLLM system instructions instead of the attachment API
- make `RubricLLM.configure` transactional so invalid settings do not poison global state
- normalize string-keyed batch samples and stabilize paired t-test p-value calculations
- bump the gem version to `0.1.1` and document the patch release in `CHANGELOG.md`

## Why
These regressions were in production-facing evaluation paths. The judge call path could fail before reaching the provider, invalid configuration could stick in long-lived processes, JSON-style batch inputs were scored incorrectly, and comparison p-values were materially wrong for small deltas.

## Changes
### fix(core): harden judge evaluation regressions
- **What:** Switched judge prompting to `with_instructions`, tightened the RubyLLM test double to match real gem behavior, and added regression coverage for the judge path.
- **Why:** Inferred: the existing tests masked a real API mismatch and let a production-breaking code path pass.
- **What:** Updated `RubricLLM.configure` to validate a cloned config before replacing the singleton configuration.
- **Why:** Prevent invalid settings from persisting after a failed configure block.
- **What:** Normalized batch dataset hashes so both symbol-keyed and string-keyed samples are evaluated correctly in sequential and concurrent runs.
- **Why:** API payloads and `JSON.parse` datasets commonly use string keys.
- **What:** Replaced the unstable incomplete beta path with a stable symmetry-aware implementation and added a numeric regression test for the reported t-statistic case.
- **Why:** Keep A/B comparison p-values credible on ordinary sample sizes.
- **What:** Bumped the release to `0.1.1` and documented the fixes.
- **Why:** Ship the regression fixes as a patch release.

## Testing
- [x] `bundle exec rake`
- [x] Added regression tests for judge instructions vs attachments
- [x] Added regression tests for config rollback, string-key batch samples, and p-value stability

## Risk & Rollout
- **Risk:** Low - the changes are localized, covered by new regressions, and verified by the full test/rubocop task.
- **Rollback:** Revert commit `ad456ad`.
- **Monitoring:** Watch judge failures, nil metric scores in batch reports, and comparison p-values after merge.