### PR TITLE
fix(core): make evaluation errors visible in results and reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-07-11
+
+### Changed
+
+- `Result#pass?` now returns `false` when any metric errored during evaluation (fail-closed for CI gating)
+- `Report#worst` now ranks results with no valid scores as worst instead of best
+
+### Added
+
+- `Result#errors` and `Result#valid?` expose per-metric judge failures
+- `Result#to_h` and report JSON exports include metric error information
+- Report summaries show a metric error count line when evaluation errors occurred
+
 ## [0.2.0] - 2026-07-11
 
 ### Changed

--- a/lib/rubric_llm/report.rb
+++ b/lib/rubric_llm/report.rb
@@ -16,7 +16,7 @@ module RubricLLM
     end
 
     def worst(n)
-      results.sort_by { |r| r.overall || Float::INFINITY }.first(n)
+      results.sort_by { |r| r.overall || -Float::INFINITY }.first(n)
     end
 
     def failures(threshold: 0.8)
@@ -33,6 +33,10 @@ module RubricLLM
         lines << format("  %-20s  mean=%.3f  std=%.3f  min=%.3f  max=%.3f  n=%d",
                         metric, stats[:mean], stats[:std], stats[:min], stats[:max], stats[:count])
       end
+
+      error_count = error_counts.values.sum
+      affected_samples = results.count { |r| r.errors.any? }
+      lines << "Errors: #{error_count} metric errors across #{affected_samples} samples" if error_count.positive?
 
       lines.join("\n")
     end
@@ -72,12 +76,19 @@ module RubricLLM
       {
         summary: metric_stats,
         duration:,
+        errors: error_counts,
         results: results.map(&:to_h)
       }
     end
 
     def all_metric_names
       results.flat_map { |r| r.scores.keys }.uniq
+    end
+
+    def error_counts
+      counts = Hash.new(0)
+      results.each { |r| r.errors.each_key { |name| counts[name] += 1 } }
+      counts
     end
 
     def compute_stats

--- a/lib/rubric_llm/result.rb
+++ b/lib/rubric_llm/result.rb
@@ -18,14 +18,26 @@ module RubricLLM
     end
 
     def pass?(threshold: 0.8)
+      return false unless valid?
+
       score = overall
       return false if score.nil?
 
       score >= threshold
     end
 
+    def errors
+      details.each_with_object({}) do |(name, detail), acc|
+        acc[name] = detail[:error] if detail.is_a?(Hash) && detail.key?(:error)
+      end
+    end
+
+    def valid?
+      errors.empty?
+    end
+
     def to_h
-      { scores:, details:, overall: overall }
+      { scores:, details:, overall: overall, errors: }
     end
 
     private

--- a/lib/rubric_llm/version.rb
+++ b/lib/rubric_llm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubricLLM
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/test/test_report.rb
+++ b/test/test_report.rb
@@ -95,7 +95,7 @@ class TestReport < Minitest::Test
     assert_equal [0.9, 0.7, 0.5], scores
   end
 
-  def test_worst_sorts_nil_overall_to_end
+  def test_worst_sorts_nil_overall_first
     results_with_nil = [
       RubricLLM::Result.new(scores: { a: nil }, details: {}, sample: { question: "nil_q" }),
       RubricLLM::Result.new(scores: { a: 0.3 }, details: {}, sample: { question: "low_q" }),
@@ -104,6 +104,63 @@ class TestReport < Minitest::Test
     report = RubricLLM::Report.new(results: results_with_nil)
     worst = report.worst(1)
 
-    assert_equal "low_q", worst.first.sample[:question]
+    assert_equal "nil_q", worst.first.sample[:question]
+  end
+
+  def test_summary_reports_metric_errors
+    results_with_errors = [
+      RubricLLM::Result.new(
+        scores: { faithfulness: nil, relevance: 0.8 },
+        details: { faithfulness: { error: "judge timeout" } },
+        sample: { question: "q1" }
+      ),
+      RubricLLM::Result.new(
+        scores: { faithfulness: nil, relevance: nil },
+        details: { faithfulness: { error: "judge timeout" }, relevance: { error: "bad response" } },
+        sample: { question: "q2" }
+      )
+    ]
+    report = RubricLLM::Report.new(results: results_with_errors)
+
+    assert_includes report.summary, "Errors: 3 metric errors across 2 samples"
+  end
+
+  def test_summary_omits_error_line_when_no_errors
+    refute_includes @report.summary, "Errors:"
+  end
+
+  def test_worst_returns_errored_result_first
+    results_with_errors = [
+      RubricLLM::Result.new(
+        scores: { a: nil },
+        details: { a: { error: "boom" } },
+        sample: { question: "errored_q" }
+      ),
+      RubricLLM::Result.new(scores: { a: 0.3 }, details: {}, sample: { question: "low_q" })
+    ]
+    report = RubricLLM::Report.new(results: results_with_errors)
+
+    assert_equal "errored_q", report.worst(1).first.sample[:question]
+  end
+
+  def test_serializable_hash_includes_error_counts
+    results_with_errors = [
+      RubricLLM::Result.new(
+        scores: { faithfulness: nil, relevance: 0.8 },
+        details: { faithfulness: { error: "judge timeout" } },
+        sample: { question: "q1" }
+      ),
+      RubricLLM::Result.new(scores: { faithfulness: 0.9, relevance: 0.7 }, details: {}, sample: { question: "q2" })
+    ]
+    report = RubricLLM::Report.new(results: results_with_errors)
+    data = JSON.parse(report.to_json)
+
+    assert_equal({ "faithfulness" => 1 }, data["errors"])
+  end
+
+  def test_serializable_hash_errors_empty_when_no_errors
+    data = JSON.parse(@report.to_json)
+
+    assert_equal({}, data["errors"])
   end
 end

--- a/test/test_result.rb
+++ b/test/test_result.rb
@@ -58,5 +58,44 @@ class TestResult < Minitest::Test
 
     assert_equal({ a: 0.9 }, hash[:scores])
     assert_in_delta 0.9, hash[:overall]
+    assert_equal({}, hash[:errors])
+  end
+
+  def test_all_nil_scores_are_invalid_and_fail
+    result = RubricLLM::Result.new(
+      scores: { faithfulness: nil },
+      details: { faithfulness: { error: "judge timeout" } }
+    )
+
+    assert_nil result.overall
+    refute_predicate result, :pass?
+    refute_predicate result, :valid?
+    assert_equal({ faithfulness: "judge timeout" }, result.errors)
+  end
+
+  def test_partial_failure_fails_pass_despite_high_overall
+    result = RubricLLM::Result.new(
+      scores: { a: nil, b: 1.0 },
+      details: { a: { error: "boom" } }
+    )
+
+    assert_in_delta 1.0, result.overall
+    refute_predicate result, :pass?
+    assert_equal({ a: "boom" }, result.errors)
+  end
+
+  def test_valid_with_no_errors
+    result = RubricLLM::Result.new(scores: { a: 0.9 }, details: {})
+
+    assert_predicate result, :valid?
+    assert_equal({}, result.errors)
+    assert result.pass?(threshold: 0.8)
+  end
+
+  def test_errors_ignores_non_hash_details
+    result = RubricLLM::Result.new(scores: { a: 0.9 }, details: { a: "some note" })
+
+    assert_equal({}, result.errors)
+    assert_predicate result, :valid?
   end
 end


### PR DESCRIPTION
Closes #4

## Problem

`Evaluator#call` rescues judge errors into `nil` scores, and downstream everything silently drops them: `Result#overall` compacts nils, `Result#pass?` can return `true` on partial data, `Report#metric_stats`/`summary` hide errored metrics, and `Report#worst` sorts nil-overall results as if they were the best. A judge outage that kills 5 of 6 metrics still shows green in CI.

## Changes

- `Result#errors` returns per-metric error messages (derived from `details` entries with an `:error` key); `Result#valid?` is true when there are none
- `Result#pass?` now fails closed: returns `false` when any metric errored, regardless of the surviving metrics' scores
- `Result#to_h` includes `errors`
- `Report#summary` appends an error line when errors occurred, e.g. `Errors: 3 metric errors across 2 samples`
- JSON export (`serializable_hash`) includes per-metric error counts under `errors`
- `Report#worst` now ranks results with no valid scores as worst instead of best
- Version bumped to 0.3.0 with CHANGELOG entry (`pass?` and `worst` are behavior changes)

`overall` intentionally stays as the mean of valid scores, a partial score is still informative; only the gate requires completeness.

## Verification

- `bundle exec rake test`: 136 runs, 301 assertions, 0 failures (9 new regression tests: all-nil scores, partial failure with high overall, error-free results, non-Hash details, report summary/worst/JSON with errors)
- `bundle exec rubocop`: no offenses
- End-to-end repro through `Evaluator` with a metric raising `JudgeError`: `{failing: nil, passing: 1.0}` now yields `pass? == false`, appears in `Report#failures`, and the summary shows the error count line

Implementation delegated to Codex, reviewed and verified with Claude Code.

CodeFactory builder