### PR TITLE
fix: correct evaluation verdicts, retries, and A/B statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The RSpec `hallucinate` matcher no longer reports a hallucination when the judge returns no score. A failed judge call previously read as a positive match and failed the build with a false verdict
 - `Comparison` pairs samples by `sample[:question]` instead of array position. Two reports built from the same dataset in a different order produced an invalid paired t-test. Questions present in only one report are dropped with a warning
-- `Judge#call` retries only transient failures (`RubyLLM::RateLimitError`, `ServerError`, `ServiceUnavailableError`, `OverloadedError`, `Faraday::ConnectionFailed`, `Faraday::TimeoutError`). A bad API key, an exhausted quota, an over-long prompt, or a judge contract violation now fails on the first attempt instead of sleeping through the full retry schedule
+- `Judge#call` retries only transient failures (`RubyLLM::RateLimitError`, `ServerError`, `ServiceUnavailableError`, `OverloadedError`). A bad API key, an exhausted quota, an over-long prompt, or a judge contract violation now fails on the first attempt instead of sleeping through the full retry schedule. Transport timeouts and connection resets are left to RubyLLM's connection, which already retries them
 - `ContextPrecision` and `ContextRecall` drop blank and whitespace-only context chunks and return a `No context provided` error when nothing usable remains, matching `Faithfulness`
 - `Statistics.two_tailed_p` rescues only `Math::DomainError`, `ZeroDivisionError`, and `FloatDomainError`. It previously swallowed every `StandardError` and returned 1.0
 - A paired t-test over a constant difference returns 1.0 instead of a spurious near-zero p-value caused by float error in the variance
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Holm-Bonferroni correction across metrics in `Comparison`. Each result carries `:p_value_adjusted` next to the raw `:p_value`, `#summary` prints a `p-adj` column, and `#significant_improvements` / `#significant_regressions` test the adjusted value. Six independent tests at alpha 0.05 gave a family-wise false-positive rate near 26%
 - `RubricLLM::Statistics`, a module holding the paired t-test, the two-tailed p-value, the Holm adjustment, and the incomplete beta function. No LLM calls, no state
 - `Metrics::Base.normalize_context`, the single definition of usable context
-- `faraday` as a runtime dependency; `Judge` names its connection error classes directly
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-08-23
+
+### Fixed
+
+- The RSpec `hallucinate` matcher no longer reports a hallucination when the judge returns no score. A failed judge call previously read as a positive match and failed the build with a false verdict
+- `Comparison` pairs samples by `sample[:question]` instead of array position. Two reports built from the same dataset in a different order produced an invalid paired t-test. Questions present in only one report are dropped with a warning
+- `Judge#call` retries only transient failures (`RubyLLM::RateLimitError`, `ServerError`, `ServiceUnavailableError`, `OverloadedError`, `Faraday::ConnectionFailed`, `Faraday::TimeoutError`). A bad API key, an exhausted quota, an over-long prompt, or a judge contract violation now fails on the first attempt instead of sleeping through the full retry schedule
+- `ContextPrecision` and `ContextRecall` drop blank and whitespace-only context chunks and return a `No context provided` error when nothing usable remains, matching `Faithfulness`
+- `Statistics.two_tailed_p` rescues only `Math::DomainError`, `ZeroDivisionError`, and `FloatDomainError`. It previously swallowed every `StandardError` and returned 1.0
+- A paired t-test over a constant difference returns 1.0 instead of a spurious near-zero p-value caused by float error in the variance
+
+### Added
+
+- Holm-Bonferroni correction across metrics in `Comparison`. Each result carries `:p_value_adjusted` next to the raw `:p_value`, `#summary` prints a `p-adj` column, and `#significant_improvements` / `#significant_regressions` test the adjusted value. Six independent tests at alpha 0.05 gave a family-wise false-positive rate near 26%
+- `RubricLLM::Statistics`, a module holding the paired t-test, the two-tailed p-value, the Holm adjustment, and the incomplete beta function. No LLM calls, no state
+- `Metrics::Base.normalize_context`, the single definition of usable context
+- `faraday` as a runtime dependency; `Judge` names its connection error classes directly
+
+### Changed
+
+- The Minitest `assert_faithful` and `refute_hallucination` helpers and the RSpec `be_faithful` and `hallucinate` matchers raise `ArgumentError` on an empty or blank context instead of returning a verdict that no judge produced
+
 ## [0.4.0] - 2026-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ContextPrecision` and `ContextRecall` drop blank and whitespace-only context chunks and return a `No context provided` error when nothing usable remains, matching `Faithfulness`
 - `Statistics.two_tailed_p` rescues only `Math::DomainError`, `ZeroDivisionError`, and `FloatDomainError`. It previously swallowed every `StandardError` and returned 1.0
 - A paired t-test over a constant difference returns 1.0 instead of a spurious near-zero p-value caused by float error in the variance
+- The RSpec `hallucinate` matcher renders a missing score as `nil` in its failure message instead of an empty string
+
+### Removed
+
+- The `Comparison` constructor no longer warns about reports of different sizes. Different sizes are fine when the questions match, and equal sizes can still drop every pair when they do not. The pairing warnings report what is actually dropped
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -217,18 +217,28 @@ comparison = RubricLLM.compare(report_a, report_b)
 
 puts comparison.summary
 # A/B Comparison
-# ======================================================================
-# Metric                      A        B    Delta    p-value  Sig
-# ----------------------------------------------------------------------
-# faithfulness                0.880    0.920   +0.040     0.0230    *
-# relevance                   0.850    0.860   +0.010     0.4210
-# correctness                 0.910    0.940   +0.030     0.0089   **
+# ================================================================================
+# Metric                      A        B    Delta    p-value      p-adj  Sig
+# --------------------------------------------------------------------------------
+# faithfulness            0.880    0.920   +0.040     0.0023     0.0068   **
+# relevance               0.850    0.860   +0.010     0.3081     0.3081
+# correctness             0.910    0.940   +0.030     0.0240     0.0480    *
+#
+# p-adj: Holm-Bonferroni adjusted across 3 metrics. Significance uses p-adj.
 
 comparison.significant_improvements   # => [:faithfulness, :correctness]
 comparison.significant_regressions    # => []
 ```
 
 Significance markers: `*` (p < 0.05), `**` (p < 0.01), `***` (p < 0.001)
+
+### Pairing
+
+A paired t-test needs the same sample on both sides. The comparison pairs results by `sample[:question]`, not by position, so a reordered dataset still gives a valid test. Questions present in only one report are dropped with a warning. If a question repeats an uneven number of times across the two reports, the extra occurrences are dropped with a warning.
+
+### Multiple comparisons
+
+Every metric gets its own t-test. Six tests at alpha 0.05 give a family-wise false-positive rate near 26%, so each raw `p_value` is corrected with the Holm-Bonferroni step-down method and reported as `p_value_adjusted`. The significance markers and both `significant_*` methods read the adjusted value. The raw value stays in the result for reference.
 
 For the statistical reasoning behind paired t-tests and how to read these p-values, see [Understanding A/B Comparison](https://github.com/dpaluy/rubric_llm/wiki/Understanding-A-B-Comparison) on the wiki.
 
@@ -338,7 +348,7 @@ Ruby has two LLM evaluation options today. Neither fits most use cases:
 | **LLM access** | Raw HTTP (OpenAI/Anthropic only) | You implement it | RubyLLM (any provider) |
 | **Rails required?** | No | Yes (engine + 6 migrations) | No |
 | **ActiveRecord?** | No | Yes | No |
-| **A/B comparison** | Basic | No | Paired t-test with p-values |
+| **A/B comparison** | Basic | No | Paired t-test with Holm-corrected p-values |
 | **Test assertions** | Minitest + RSpec | No | Minitest + RSpec |
 | **Pluggable metrics** | No (fixed set) | Yes | Yes |
 | **Retrieval metrics** | Yes | No | Yes |

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Significance markers: `*` (p < 0.05), `**` (p < 0.01), `***` (p < 0.001)
 
 A paired t-test needs the same sample on both sides. The comparison pairs results by `sample[:question]`, not by position, so a reordered dataset still gives a valid test. Questions present in only one report are dropped with a warning. If a question repeats an uneven number of times across the two reports, the extra occurrences are dropped with a warning.
 
+`evaluate_batch` requires a `:question` on every sample, so reports it produces always pair by identity. Hand-built reports whose results carry no `sample[:question]` fall back to position pairing and warn.
+
 ### Multiple comparisons
 
 Every metric gets its own t-test. Six tests at alpha 0.05 give a family-wise false-positive rate near 26%, so each raw `p_value` is corrected with the Holm-Bonferroni step-down method and reported as `p_value_adjusted`. The significance markers and both `significant_*` methods read the adjusted value. The raw value stays in the result for reference.

--- a/lib/rubric_llm.rb
+++ b/lib/rubric_llm.rb
@@ -16,6 +16,7 @@ require_relative "rubric_llm/metrics/factual_accuracy"
 require_relative "rubric_llm/result"
 require_relative "rubric_llm/evaluator"
 require_relative "rubric_llm/report"
+require_relative "rubric_llm/statistics"
 require_relative "rubric_llm/comparison"
 require_relative "rubric_llm/retrieval_result"
 

--- a/lib/rubric_llm/comparison.rb
+++ b/lib/rubric_llm/comparison.rb
@@ -7,12 +7,6 @@ module RubricLLM
     def initialize(report_a, report_b)
       @report_a = report_a
       @report_b = report_b
-
-      return if report_a.results.size == report_b.results.size
-
-      warn "[RubricLLM] Comparison reports have different sizes " \
-           "(#{report_a.results.size} vs #{report_b.results.size}). " \
-           "Unmatched pairs will be dropped."
     end
 
     def results
@@ -86,8 +80,10 @@ module RubricLLM
       groups_a = report_a.results.group_by { |result| pair_key(result) }
       groups_b = report_b.results.group_by { |result| pair_key(result) }
 
+      warn_unkeyed(groups_a[nil].to_a.size + groups_b[nil].to_a.size)
+
       matched = groups_a.keys & groups_b.keys
-      warn_unmatched((groups_a.keys | groups_b.keys) - matched)
+      warn_unmatched(((groups_a.keys | groups_b.keys) - matched).compact)
 
       matched.flat_map do |key|
         list_a = groups_a[key]
@@ -102,6 +98,15 @@ module RubricLLM
     def pair_key(result)
       sample = result.sample
       sample.is_a?(Hash) ? sample[:question] : nil
+    end
+
+    # Results with no sample[:question] share one bucket and pair by position,
+    # which is the behaviour identity pairing exists to replace. Say so.
+    def warn_unkeyed(count)
+      return if count.zero?
+
+      warn "[RubricLLM] #{count} result(s) have no sample[:question]. They share one bucket and " \
+           "pair by position. Give every sample a :question to pair them reliably."
     end
 
     def warn_unmatched(keys)

--- a/lib/rubric_llm/comparison.rb
+++ b/lib/rubric_llm/comparison.rb
@@ -21,24 +21,27 @@ module RubricLLM
 
     def summary
       lines = ["A/B Comparison"]
-      lines << ("=" * 70)
-      lines << "Metric                      A        B    Delta    p-value  Sig"
-      lines << ("-" * 70)
+      lines << ("=" * 80)
+      lines << "Metric                      A        B    Delta    p-value      p-adj  Sig"
+      lines << ("-" * 80)
 
       results.each do |metric, r|
-        lines << format("%-20s %8.3f %8.3f %+8.3f %10.4f %4s",
-                        metric, r[:mean_a], r[:mean_b], r[:delta], r[:p_value], r[:significance])
+        lines << format("%-20s %8.3f %8.3f %+8.3f %10.4f %10.4f %4s",
+                        metric, r[:mean_a], r[:mean_b], r[:delta], r[:p_value], r[:p_value_adjusted],
+                        r[:significance])
       end
 
+      lines << ""
+      lines << "p-adj: Holm-Bonferroni adjusted across #{results.size} metrics. Significance uses p-adj."
       lines.join("\n")
     end
 
     def significant_improvements(alpha: 0.05)
-      results.select { |_, r| r[:p_value] < alpha && r[:delta].positive? }.keys
+      results.select { |_, r| r[:p_value_adjusted] < alpha && r[:delta].positive? }.keys
     end
 
     def significant_regressions(alpha: 0.05)
-      results.select { |_, r| r[:p_value] < alpha && r[:delta].negative? }.keys
+      results.select { |_, r| r[:p_value_adjusted] < alpha && r[:delta].negative? }.keys
     end
 
     private
@@ -46,110 +49,87 @@ module RubricLLM
     def compute_results
       metrics = (report_a.metric_stats.keys | report_b.metric_stats.keys)
 
-      metrics.each_with_object({}) do |metric, hash|
-        paired_scores = report_a.scores_for(metric)
-                                .zip(report_b.scores_for(metric))
-                                .select { |score_a, score_b| !score_a.nil? && !score_b.nil? }
+      raw = metrics.each_with_object({}) do |metric, hash|
+        stats = metric_stats(metric)
+        hash[metric] = stats if stats
+      end
 
-        next if paired_scores.empty?
+      apply_holm_correction(raw)
+    end
 
-        scores_a, scores_b = paired_scores.transpose
+    def metric_stats(metric)
+      paired_scores = paired_results
+                      .map { |result_a, result_b| [result_a.scores[metric], result_b.scores[metric]] }
+                      .reject { |score_a, score_b| score_a.nil? || score_b.nil? }
 
-        mean_a = scores_a.sum / scores_a.size.to_f
-        mean_b = scores_b.sum / scores_b.size.to_f
-        delta = mean_b - mean_a
-        p_value = paired_t_test(scores_a, scores_b)
+      return nil if paired_scores.empty?
 
-        hash[metric] = {
-          mean_a:,
-          mean_b:,
-          delta:,
-          p_value:,
-          significance: significance_marker(p_value)
-        }
+      scores_a, scores_b = paired_scores.transpose
+      mean_a = scores_a.sum / scores_a.size.to_f
+      mean_b = scores_b.sum / scores_b.size.to_f
+
+      {
+        mean_a:,
+        mean_b:,
+        delta: mean_b - mean_a,
+        p_value: Statistics.paired_t_test(scores_a, scores_b)
+      }
+    end
+
+    # A paired t-test requires the same sample on both sides. Pair by question
+    # instead of array position so a reordered dataset stays valid.
+    def paired_results
+      @paired_results ||= build_pairs
+    end
+
+    def build_pairs
+      groups_a = report_a.results.group_by { |result| pair_key(result) }
+      groups_b = report_b.results.group_by { |result| pair_key(result) }
+
+      matched = groups_a.keys & groups_b.keys
+      warn_unmatched((groups_a.keys | groups_b.keys) - matched)
+
+      matched.flat_map do |key|
+        list_a = groups_a[key]
+        list_b = groups_b[key]
+        warn_uneven(key, list_a.size, list_b.size) unless list_a.size == list_b.size
+
+        size = [list_a.size, list_b.size].min
+        list_a.first(size).zip(list_b.first(size))
       end
     end
 
-    def paired_t_test(a, b)
-      n = [a.size, b.size].min
-      return 1.0 if n < 2
-
-      diffs = a.first(n).zip(b.first(n)).map { |x, y| y - x }
-      mean_d = diffs.sum / n.to_f
-      var_d = diffs.sum { |d| (d - mean_d)**2 } / (n - 1).to_f
-      se = Math.sqrt(var_d / n)
-
-      return 1.0 if se.zero?
-
-      t = mean_d / se
-      df = n - 1
-
-      # Two-tailed p-value approximation using Student's t-distribution
-      two_tailed_p(t.abs, df)
+    def pair_key(result)
+      sample = result.sample
+      sample.is_a?(Hash) ? sample[:question] : nil
     end
 
-    # Two-tailed p-value for Student's t-distribution.
-    # p = I_x(df/2, 1/2) where x = df/(df + t²)
-    def two_tailed_p(t, df)
-      x = df / (df + (t**2))
-      regularized_beta(x, df / 2.0, 0.5)
-    rescue StandardError
-      1.0
+    def warn_unmatched(keys)
+      return if keys.empty?
+
+      warn "[RubricLLM] Comparison dropped #{keys.size} question(s) present in only one report. " \
+           "Paired tests need the same questions on both sides."
     end
 
-    # Regularized incomplete beta function via continued fraction (Lentz's method).
-    def regularized_beta(x, a, b)
-      return 0.0 if x <= 0.0
-      return 1.0 if x >= 1.0
-
-      ln_beta = Math.lgamma(a + b)[0] - Math.lgamma(a)[0] - Math.lgamma(b)[0]
-      front = Math.exp(ln_beta + (a * Math.log(x)) + (b * Math.log(1.0 - x)))
-
-      result = if x < ((a + 1.0) / (a + b + 2.0))
-                 front * beta_continued_fraction(a, b, x) / a
-               else
-                 1.0 - ((front * beta_continued_fraction(b, a, 1.0 - x)) / b)
-               end
-
-      result.clamp(0.0, 1.0)
+    def warn_uneven(key, size_a, size_b)
+      warn "[RubricLLM] Question #{key.inspect} appears #{size_a} time(s) in report A and " \
+           "#{size_b} time(s) in report B. Extra occurrences are dropped."
     end
 
-    def beta_continued_fraction(a, b, x)
-      tiny = 1e-30
-      qab = a + b
-      qap = a + 1.0
-      qam = a - 1.0
+    # One t-test per metric inflates the family-wise error rate, so adjust
+    # before calling any metric significant.
+    def apply_holm_correction(results)
+      metrics = results.keys
+      adjusted = Statistics.holm_adjust(metrics.map { |metric| results[metric][:p_value] })
 
-      c = 1.0
-      d = 1.0 - ((qab * x) / qap)
-      d = tiny if d.abs < tiny
-      d = 1.0 / d
-      fraction = d
-
-      (1..200).each do |m|
-        m2 = 2 * m
-
-        numerator = (m * (b - m) * x) / ((qam + m2) * (a + m2))
-        d = 1.0 + (numerator * d)
-        d = tiny if d.abs < tiny
-        c = 1.0 + (numerator / c)
-        c = tiny if c.abs < tiny
-        d = 1.0 / d
-        fraction *= c * d
-
-        numerator = -((a + m) * (qab + m) * x) / ((a + m2) * (qap + m2))
-        d = 1.0 + (numerator * d)
-        d = tiny if d.abs < tiny
-        c = 1.0 + (numerator / c)
-        c = tiny if c.abs < tiny
-        d = 1.0 / d
-        delta = c * d
-        fraction *= delta
-
-        break if (delta - 1.0).abs < 1e-12
+      metrics.each_with_index do |metric, index|
+        results[metric] = results[metric].merge(
+          p_value_adjusted: adjusted[index],
+          significance: significance_marker(adjusted[index])
+        )
       end
 
-      fraction
+      results
     end
 
     def significance_marker(p)

--- a/lib/rubric_llm/judge.rb
+++ b/lib/rubric_llm/judge.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
 require "json"
-require "faraday"
 
 module RubricLLM
   class Judge
     # Failures worth retrying: the same request may succeed later.
     # Everything else (bad key, no credit, malformed request, prompt too long,
     # contract violations in the judge response) fails on the first attempt.
+    #
+    # Transport failures are absent on purpose. RubyLLM's connection already
+    # retries timeouts and connection resets, so by the time one reaches us it
+    # has been tried several times and is not worth another round.
     TRANSIENT_ERRORS = [
       RubyLLM::RateLimitError,
       RubyLLM::ServerError,
       RubyLLM::ServiceUnavailableError,
-      RubyLLM::OverloadedError,
-      Faraday::ConnectionFailed,
-      Faraday::TimeoutError
+      RubyLLM::OverloadedError
     ].freeze
 
     METRIC_RESPONSE_SCHEMA = {

--- a/lib/rubric_llm/judge.rb
+++ b/lib/rubric_llm/judge.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
 
 require "json"
+require "faraday"
 
 module RubricLLM
   class Judge
+    # Failures worth retrying: the same request may succeed later.
+    # Everything else (bad key, no credit, malformed request, prompt too long,
+    # contract violations in the judge response) fails on the first attempt.
+    TRANSIENT_ERRORS = [
+      RubyLLM::RateLimitError,
+      RubyLLM::ServerError,
+      RubyLLM::ServiceUnavailableError,
+      RubyLLM::OverloadedError,
+      Faraday::ConnectionFailed,
+      Faraday::TimeoutError
+    ].freeze
+
     METRIC_RESPONSE_SCHEMA = {
       name: "rubric_llm_metric_response",
       strict: false,
@@ -46,11 +59,7 @@ module RubricLLM
         content = response.content
         validate_response!(content.is_a?(Hash) ? content : parse_json(content))
       rescue StandardError => e
-        if attempts > config.max_retries
-          raise e if e.is_a?(JudgeError)
-
-          raise JudgeError, "Judge call failed: #{e.message}"
-        end
+        raise wrap_error(e) unless transient?(e) && attempts <= config.max_retries
 
         sleep(config.retry_base_delay * (2**(attempts - 1)))
         retry
@@ -78,6 +87,16 @@ module RubricLLM
     end
 
     private
+
+    def transient?(error)
+      TRANSIENT_ERRORS.any? { |klass| error.is_a?(klass) }
+    end
+
+    def wrap_error(error)
+      return error if error.is_a?(JudgeError)
+
+      JudgeError.new("Judge call failed: #{error.message}")
+    end
 
     def apply_response_schema(chat)
       return chat unless chat.respond_to?(:with_schema)

--- a/lib/rubric_llm/metrics/base.rb
+++ b/lib/rubric_llm/metrics/base.rb
@@ -9,6 +9,14 @@ module RubricLLM
         Array(context).map { |chunk| chunk.to_s.strip }.reject(&:empty?)
       end
 
+      # An empty context cannot produce a faithfulness score. Reject it as a caller
+      # error instead of letting a nil score read as a quality verdict.
+      def self.require_context!(context)
+        return unless normalize_context(context).empty?
+
+        raise ArgumentError, "context must contain at least one non-empty entry"
+      end
+
       attr_reader :judge
 
       def initialize(judge:)

--- a/lib/rubric_llm/metrics/base.rb
+++ b/lib/rubric_llm/metrics/base.rb
@@ -3,6 +3,12 @@
 module RubricLLM
   module Metrics
     class Base
+      # Single source of truth for what counts as usable context.
+      # Blank and whitespace-only chunks are dropped.
+      def self.normalize_context(context)
+        Array(context).map { |chunk| chunk.to_s.strip }.reject(&:empty?)
+      end
+
       attr_reader :judge
 
       def initialize(judge:)

--- a/lib/rubric_llm/metrics/context_precision.rb
+++ b/lib/rubric_llm/metrics/context_precision.rb
@@ -16,13 +16,14 @@ module RubricLLM
       PROMPT
 
       def call(question:, context: [], **)
-        return { score: nil, details: { error: "No context provided" } } if Array(context).empty?
+        context_chunks = Base.normalize_context(context)
+        return { score: nil, details: { error: "No context provided" } } if context_chunks.empty?
 
         user_prompt = <<~PROMPT
           Question: #{question}
 
           Contexts:
-          #{Array(context).each_with_index.map { |c, i| "#{i + 1}. #{c}" }.join("\n")}
+          #{context_chunks.each_with_index.map { |c, i| "#{i + 1}. #{c}" }.join("\n")}
 
           Evaluate how relevant each context is to the question.
         PROMPT

--- a/lib/rubric_llm/metrics/context_recall.rb
+++ b/lib/rubric_llm/metrics/context_recall.rb
@@ -17,11 +17,13 @@ module RubricLLM
 
       def call(context: [], ground_truth: nil, **)
         return { score: nil, details: { error: "No ground truth provided" } } if ground_truth.nil?
-        return { score: nil, details: { error: "No context provided" } } if Array(context).empty?
+
+        context_chunks = Base.normalize_context(context)
+        return { score: nil, details: { error: "No context provided" } } if context_chunks.empty?
 
         user_prompt = <<~PROMPT
           Contexts:
-          #{Array(context).each_with_index.map { |c, i| "#{i + 1}. #{c}" }.join("\n")}
+          #{context_chunks.each_with_index.map { |c, i| "#{i + 1}. #{c}" }.join("\n")}
 
           Ground Truth: #{ground_truth}
 

--- a/lib/rubric_llm/metrics/faithfulness.rb
+++ b/lib/rubric_llm/metrics/faithfulness.rb
@@ -16,7 +16,7 @@ module RubricLLM
       PROMPT
 
       def call(question:, answer:, context: [], **)
-        context_chunks = Array(context).map { |chunk| chunk.to_s.strip }.reject(&:empty?)
+        context_chunks = Base.normalize_context(context)
         return { score: nil, details: { error: "No context provided" } } if context_chunks.empty?
 
         user_prompt = <<~PROMPT

--- a/lib/rubric_llm/minitest.rb
+++ b/lib/rubric_llm/minitest.rb
@@ -5,6 +5,7 @@ require "rubric_llm"
 module RubricLLM
   module Assertions
     def assert_faithful(answer, context, question: "", threshold: DEFAULT_THRESHOLD, config: RubricLLM.config)
+      require_context!(context)
       result = evaluate_metric(Metrics::Faithfulness, question:, answer:, context:, config:)
       score = result[:score]
 
@@ -29,6 +30,7 @@ module RubricLLM
     end
 
     def refute_hallucination(answer, context, question: "", threshold: DEFAULT_THRESHOLD, config: RubricLLM.config)
+      require_context!(context)
       result = evaluate_metric(Metrics::Faithfulness, question:, answer:, context:, config:)
       score = result[:score]
 
@@ -37,6 +39,14 @@ module RubricLLM
     end
 
     private
+
+    # An empty context cannot produce a faithfulness score. Reject it as a caller
+    # error instead of letting a nil score read as a quality verdict.
+    def require_context!(context)
+      return unless Metrics::Base.normalize_context(context).empty?
+
+      raise ArgumentError, "context must contain at least one non-empty entry"
+    end
 
     def evaluate_metric(metric_class, config:, **)
       judge = Judge.new(config:)

--- a/lib/rubric_llm/minitest.rb
+++ b/lib/rubric_llm/minitest.rb
@@ -40,12 +40,8 @@ module RubricLLM
 
     private
 
-    # An empty context cannot produce a faithfulness score. Reject it as a caller
-    # error instead of letting a nil score read as a quality verdict.
     def require_context!(context)
-      return unless Metrics::Base.normalize_context(context).empty?
-
-      raise ArgumentError, "context must contain at least one non-empty entry"
+      Metrics::Base.require_context!(context)
     end
 
     def evaluate_metric(metric_class, config:, **)

--- a/lib/rubric_llm/rspec.rb
+++ b/lib/rubric_llm/rspec.rb
@@ -40,12 +40,8 @@ module RubricLLM
 
       private
 
-      # An empty context cannot produce a faithfulness score. Reject it as a caller
-      # error instead of letting a nil score read as a quality verdict.
       def require_context!(context)
-        return unless Metrics::Base.normalize_context(context).empty?
-
-        raise ArgumentError, "context must contain at least one non-empty entry"
+        Metrics::Base.require_context!(context)
       end
 
       def evaluate(metric_class, **)
@@ -134,7 +130,7 @@ module RubricLLM
       end
 
       def failure_message
-        "expected hallucination (faithfulness < #{threshold}), got #{result[:score]}"
+        "expected hallucination (faithfulness < #{threshold}), got #{result[:score] || "nil"}"
       end
 
       def failure_message_when_negated

--- a/lib/rubric_llm/rspec.rb
+++ b/lib/rubric_llm/rspec.rb
@@ -40,6 +40,14 @@ module RubricLLM
 
       private
 
+      # An empty context cannot produce a faithfulness score. Reject it as a caller
+      # error instead of letting a nil score read as a quality verdict.
+      def require_context!(context)
+        return unless Metrics::Base.normalize_context(context).empty?
+
+        raise ArgumentError, "context must contain at least one non-empty entry"
+      end
+
       def evaluate(metric_class, **)
         judge = Judge.new(config:)
         metric = metric_class.new(judge:)
@@ -51,6 +59,7 @@ module RubricLLM
     class FaithfulnessMatcher < BaseMatcher
       def initialize(context, question: nil)
         super()
+        require_context!(context)
         @context = context
         @question = question
       end
@@ -113,13 +122,15 @@ module RubricLLM
     class HallucinationMatcher < BaseMatcher
       def initialize(context, question: nil)
         super()
+        require_context!(context)
         @context = context
         @question = question
       end
 
+      # Fail closed: a missing score is not evidence of a hallucination.
       def matches?(answer)
         score = evaluate(Metrics::Faithfulness, question: @question || "", answer:, context: @context)
-        score.nil? || score < threshold
+        !score.nil? && score < threshold
       end
 
       def failure_message

--- a/lib/rubric_llm/statistics.rb
+++ b/lib/rubric_llm/statistics.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module RubricLLM
+  # Pure statistical helpers. No LLM calls, no state.
+  module Statistics
+    module_function
+
+    # Two-tailed paired t-test. Both arrays must already be paired and equal length.
+    # Returns 1.0 when there is nothing to test.
+    def paired_t_test(scores_a, scores_b)
+      n = scores_a.size
+      return 1.0 if n < 2
+
+      diffs = scores_a.zip(scores_b).map { |x, y| y - x }
+      mean_d = diffs.sum / n.to_f
+      var_d = diffs.sum { |d| (d - mean_d)**2 } / (n - 1).to_f
+      se = Math.sqrt(var_d / n)
+
+      # A constant shift has no spread to test. Compare against the scale of the
+      # data rather than exact zero, or float error turns it into a huge t value.
+      return 1.0 if se <= Float::EPSILON * [mean_d.abs, 1.0].max
+
+      two_tailed_p((mean_d / se).abs, n - 1)
+    end
+
+    # Two-tailed p-value for Student's t-distribution.
+    # p = I_x(df/2, 1/2) where x = df/(df + t²)
+    def two_tailed_p(t, df)
+      x = df / (df + (t**2))
+      regularized_beta(x, df / 2.0, 0.5)
+    rescue Math::DomainError, ZeroDivisionError, FloatDomainError
+      1.0
+    end
+
+    # Holm-Bonferroni step-down adjustment.
+    # Takes p-values in any order, returns adjusted values in the same order.
+    def holm_adjust(p_values)
+      count = p_values.size
+      return p_values.dup if count.zero?
+
+      adjusted = Array.new(count)
+      running_max = 0.0
+
+      p_values.each_with_index.sort_by(&:first).each_with_index do |(p_value, position), rank|
+        running_max = ((count - rank) * p_value).clamp(running_max, 1.0)
+        adjusted[position] = running_max
+      end
+
+      adjusted
+    end
+
+    # Regularized incomplete beta function via continued fraction (Lentz's method).
+    def regularized_beta(x, a, b)
+      return 0.0 if x <= 0.0
+      return 1.0 if x >= 1.0
+
+      ln_beta = Math.lgamma(a + b)[0] - Math.lgamma(a)[0] - Math.lgamma(b)[0]
+      front = Math.exp(ln_beta + (a * Math.log(x)) + (b * Math.log(1.0 - x)))
+
+      result = if x < ((a + 1.0) / (a + b + 2.0))
+                 front * beta_continued_fraction(a, b, x) / a
+               else
+                 1.0 - ((front * beta_continued_fraction(b, a, 1.0 - x)) / b)
+               end
+
+      result.clamp(0.0, 1.0)
+    end
+
+    def beta_continued_fraction(a, b, x)
+      tiny = 1e-30
+      qab = a + b
+      qap = a + 1.0
+      qam = a - 1.0
+
+      c = 1.0
+      d = 1.0 - ((qab * x) / qap)
+      d = tiny if d.abs < tiny
+      d = 1.0 / d
+      fraction = d
+
+      (1..200).each do |m|
+        m2 = 2 * m
+
+        numerator = (m * (b - m) * x) / ((qam + m2) * (a + m2))
+        d = 1.0 + (numerator * d)
+        d = tiny if d.abs < tiny
+        c = 1.0 + (numerator / c)
+        c = tiny if c.abs < tiny
+        d = 1.0 / d
+        fraction *= c * d
+
+        numerator = -((a + m) * (qab + m) * x) / ((a + m2) * (qap + m2))
+        d = 1.0 + (numerator * d)
+        d = tiny if d.abs < tiny
+        c = 1.0 + (numerator / c)
+        c = tiny if c.abs < tiny
+        d = 1.0 / d
+        delta = c * d
+        fraction *= delta
+
+        break if (delta - 1.0).abs < 1e-12
+      end
+
+      fraction
+    end
+  end
+end

--- a/lib/rubric_llm/version.rb
+++ b/lib/rubric_llm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubricLLM
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/rubric_llm.gemspec
+++ b/rubric_llm.gemspec
@@ -38,6 +38,5 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = Dir["README.md", "CHANGELOG.md", "LICENSE.txt"]
 
   spec.add_dependency "csv"
-  spec.add_dependency "faraday"
   spec.add_dependency "ruby_llm", "~> 1.16"
 end

--- a/rubric_llm.gemspec
+++ b/rubric_llm.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = Dir["README.md", "CHANGELOG.md", "LICENSE.txt"]
 
   spec.add_dependency "csv"
+  spec.add_dependency "faraday"
   spec.add_dependency "ruby_llm", "~> 1.16"
 end

--- a/test/test_assertions.rb
+++ b/test/test_assertions.rb
@@ -39,4 +39,18 @@ class TestAssertions < Minitest::Test
 
     refute_hallucination "Paris", ["Paris is the capital of France."]
   end
+
+  def test_refute_hallucination_rejects_empty_context
+    error = assert_raises(ArgumentError) do
+      refute_hallucination "Paris", []
+    end
+
+    assert_includes error.message, "non-empty"
+  end
+
+  def test_assert_faithful_rejects_empty_context
+    assert_raises(ArgumentError) do
+      assert_faithful "Paris", ["  "]
+    end
+  end
 end

--- a/test/test_comparison.rb
+++ b/test/test_comparison.rb
@@ -92,9 +92,87 @@ class TestComparison < Minitest::Test
     assert_in_delta 0.15, result[:delta], 0.001
   end
 
-  def test_two_tailed_p_handles_values_close_to_one
-    p_value = @comparison.send(:two_tailed_p, 0.02105086415353341, 72)
+  # --- Pairing by identity ---
 
-    assert_in_delta 0.9832633107858819, p_value, 1e-9
+  def test_pairs_samples_by_question_not_position
+    report_a = build_report({ "q1" => 0.5, "q2" => 0.6, "q3" => 0.7 })
+    ordered_b = build_report({ "q1" => 0.8, "q2" => 0.85, "q3" => 1.0 })
+    shuffled_b = build_report({ "q3" => 1.0, "q1" => 0.8, "q2" => 0.85 })
+
+    ordered = RubricLLM::Comparison.new(report_a, ordered_b).results[:faithfulness]
+    shuffled = RubricLLM::Comparison.new(report_a, shuffled_b).results[:faithfulness]
+
+    assert_in_delta ordered[:p_value], shuffled[:p_value], 1e-12
+    assert_in_delta ordered[:delta], shuffled[:delta], 1e-12
+    assert_operator ordered[:p_value], :<, 0.05
+  end
+
+  def test_drops_and_warns_for_questions_missing_from_one_report
+    report_a = build_report({ "q1" => 0.5, "q2" => 0.6 })
+    report_b = build_report({ "q1" => 0.9, "q3" => 0.4 })
+    comparison = RubricLLM::Comparison.new(report_a, report_b)
+
+    output = capture_io { comparison.results }
+
+    assert_match(/dropped 2 question/, output[1])
+    assert_in_delta 0.5, comparison.results[:faithfulness][:mean_a], 0.001
+    assert_in_delta 0.9, comparison.results[:faithfulness][:mean_b], 0.001
+  end
+
+  def test_warns_when_a_question_repeats_unevenly
+    report_a = RubricLLM::Report.new(results: [
+                                       result_for("q1", 0.5),
+                                       result_for("q1", 0.6)
+                                     ])
+    report_b = RubricLLM::Report.new(results: [result_for("q1", 0.9)])
+
+    output = capture_io { RubricLLM::Comparison.new(report_a, report_b).results }
+
+    assert_match(/appears 2 time\(s\) in report A/, output[1])
+  end
+
+  # --- Multiple comparison correction ---
+
+  def test_holm_adjustment_scales_by_metric_count
+    report_a = build_report({ "q1" => 0.5, "q2" => 0.6, "q3" => 0.7 }, flat: 0.5)
+    report_b = build_report({ "q1" => 0.8, "q2" => 0.85, "q3" => 1.0 }, flat: 0.5)
+
+    results = RubricLLM::Comparison.new(report_a, report_b).results
+    faithfulness = results[:faithfulness]
+
+    assert_equal 2, results.size
+    assert_in_delta faithfulness[:p_value] * 2, faithfulness[:p_value_adjusted], 1e-9
+    assert_in_delta 1.0, results[:flat][:p_value_adjusted], 1e-9
+  end
+
+  def test_adjusted_p_value_is_never_below_the_raw_p_value
+    results = @comparison.results
+
+    results.each_value do |stats|
+      assert_operator stats[:p_value_adjusted], :>=, stats[:p_value]
+    end
+  end
+
+  def test_summary_reports_adjusted_p_values
+    summary = @comparison.summary
+
+    assert_includes summary, "p-adj"
+    assert_includes summary, "Holm-Bonferroni"
+  end
+
+  private
+
+  def build_report(scores_by_question, flat: nil)
+    results = scores_by_question.map do |question, score|
+      scores = { faithfulness: score }
+      scores[:flat] = flat unless flat.nil?
+      RubricLLM::Result.new(scores:, details: {}, sample: { question: })
+    end
+
+    RubricLLM::Report.new(results:)
+  end
+
+  def result_for(question, score)
+    RubricLLM::Result.new(scores: { faithfulness: score }, details: {}, sample: { question: })
   end
 end

--- a/test/test_comparison.rb
+++ b/test/test_comparison.rb
@@ -5,14 +5,14 @@ require "test_helper"
 class TestComparison < Minitest::Test
   def setup
     results_a = [
-      RubricLLM::Result.new(scores: { faithfulness: 0.7, relevance: 0.6 }, details: {}, sample: {}),
-      RubricLLM::Result.new(scores: { faithfulness: 0.6, relevance: 0.5 }, details: {}, sample: {}),
-      RubricLLM::Result.new(scores: { faithfulness: 0.65, relevance: 0.55 }, details: {}, sample: {})
+      scored("q1", faithfulness: 0.7, relevance: 0.6),
+      scored("q2", faithfulness: 0.6, relevance: 0.5),
+      scored("q3", faithfulness: 0.65, relevance: 0.55)
     ]
     results_b = [
-      RubricLLM::Result.new(scores: { faithfulness: 0.9, relevance: 0.6 }, details: {}, sample: {}),
-      RubricLLM::Result.new(scores: { faithfulness: 0.85, relevance: 0.5 }, details: {}, sample: {}),
-      RubricLLM::Result.new(scores: { faithfulness: 0.88, relevance: 0.55 }, details: {}, sample: {})
+      scored("q1", faithfulness: 0.9, relevance: 0.6),
+      scored("q2", faithfulness: 0.85, relevance: 0.5),
+      scored("q3", faithfulness: 0.88, relevance: 0.55)
     ]
 
     @report_a = RubricLLM::Report.new(results: results_a)
@@ -59,37 +59,37 @@ class TestComparison < Minitest::Test
     refute_includes regressions, :relevance
   end
 
-  def test_warns_on_mismatched_report_sizes
-    report_a = RubricLLM::Report.new(results: [
-                                       RubricLLM::Result.new(scores: { faithfulness: 0.5 }, details: {}, sample: {})
-                                     ])
-    report_b = RubricLLM::Report.new(results: [
-                                       RubricLLM::Result.new(scores: { faithfulness: 0.6 }, details: {}, sample: {}),
-                                       RubricLLM::Result.new(scores: { faithfulness: 0.7 }, details: {}, sample: {})
-                                     ])
-
-    output = capture_io { RubricLLM::Comparison.new(report_a, report_b) }
-
-    assert_match(/different sizes/, output[1])
-  end
-
   def test_results_keep_pairs_aligned_when_filtering_nil_scores
-    report_a = RubricLLM::Report.new(results: [
-                                       RubricLLM::Result.new(scores: { faithfulness: 0.2 }, details: {}, sample: {}),
-                                       RubricLLM::Result.new(scores: { faithfulness: nil }, details: {}, sample: {}),
-                                       RubricLLM::Result.new(scores: { faithfulness: 0.9 }, details: {}, sample: {})
-                                     ])
-    report_b = RubricLLM::Report.new(results: [
-                                       RubricLLM::Result.new(scores: { faithfulness: 0.4 }, details: {}, sample: {}),
-                                       RubricLLM::Result.new(scores: { faithfulness: 0.6 }, details: {}, sample: {}),
-                                       RubricLLM::Result.new(scores: { faithfulness: 1.0 }, details: {}, sample: {})
-                                     ])
+    report_a = build_report({ "q1" => 0.2, "q2" => nil, "q3" => 0.9 })
+    report_b = build_report({ "q1" => 0.4, "q2" => 0.6, "q3" => 1.0 })
 
     result = RubricLLM::Comparison.new(report_a, report_b).results[:faithfulness]
 
     assert_in_delta 0.55, result[:mean_a], 0.001
     assert_in_delta 0.7, result[:mean_b], 0.001
     assert_in_delta 0.15, result[:delta], 0.001
+  end
+
+  def test_warns_when_results_carry_no_question
+    report_a = RubricLLM::Report.new(results: [
+                                       RubricLLM::Result.new(scores: { faithfulness: 0.5 }, details: {}, sample: {})
+                                     ])
+    report_b = RubricLLM::Report.new(results: [
+                                       RubricLLM::Result.new(scores: { faithfulness: 0.6 }, details: {}, sample: {})
+                                     ])
+
+    output = capture_io { RubricLLM::Comparison.new(report_a, report_b).results }
+
+    assert_match(/2 result\(s\) have no sample\[:question\]/, output[1])
+  end
+
+  def test_does_not_warn_when_every_result_carries_a_question
+    report_a = build_report({ "q1" => 0.5, "q2" => 0.6 })
+    report_b = build_report({ "q1" => 0.9, "q2" => 0.8 })
+
+    output = capture_io { RubricLLM::Comparison.new(report_a, report_b).results }
+
+    assert_empty output[1]
   end
 
   # --- Pairing by identity ---
@@ -174,5 +174,9 @@ class TestComparison < Minitest::Test
 
   def result_for(question, score)
     RubricLLM::Result.new(scores: { faithfulness: score }, details: {}, sample: { question: })
+  end
+
+  def scored(question, **scores)
+    RubricLLM::Result.new(scores:, details: {}, sample: { question: })
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -90,6 +90,9 @@ module RubyLLMStub
   end
 end
 
+# Keep a handle on the real RubyLLM so tests can name its error classes.
+RubyLLMReal = RubyLLM if defined?(RubyLLM) && RubyLLM != RubyLLMStub
+
 # Replace RubyLLM with our stub for all tests
 Object.send(:remove_const, :RubyLLM) if defined?(RubyLLM) && RubyLLM != RubyLLMStub
 RubyLLM = RubyLLMStub

--- a/test/test_judge.rb
+++ b/test/test_judge.rb
@@ -115,17 +115,21 @@ class TestJudge < Minitest::Test
     assert_equal 2, chat.call_count
   end
 
-  def test_call_retries_connection_failures
+  # RubyLLM's connection retries transport failures before they reach us, so a
+  # second retry loop here only multiplies the request count.
+  def test_call_leaves_transport_failures_to_ruby_llm
     chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}', fail_times: 1,
-                                     error_class: Faraday::ConnectionFailed)
+                                     error_class: Errno::ECONNRESET)
     RubyLLMStub.fake_chat = chat
 
-    config = RubricLLM::Config.new(max_retries: 2, retry_base_delay: 0.0)
+    config = RubricLLM::Config.new(max_retries: 3, retry_base_delay: 0.0)
     judge = RubricLLM::Judge.new(config:)
-    result = judge.call(system_prompt: "test", user_prompt: "test")
 
-    assert_in_delta 0.9, result["score"]
-    assert_equal 2, chat.call_count
+    assert_raises(RubricLLM::JudgeError) do
+      judge.call(system_prompt: "test", user_prompt: "test")
+    end
+
+    assert_equal 1, chat.call_count
   end
 
   def test_call_raises_after_exhausting_retries

--- a/test/test_judge.rb
+++ b/test/test_judge.rb
@@ -103,7 +103,21 @@ class TestJudge < Minitest::Test
   end
 
   def test_call_retries_on_transient_failure
-    chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}', fail_times: 1)
+    chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}', fail_times: 1,
+                                     error_class: RubyLLMReal::ServiceUnavailableError)
+    RubyLLMStub.fake_chat = chat
+
+    config = RubricLLM::Config.new(max_retries: 2, retry_base_delay: 0.0)
+    judge = RubricLLM::Judge.new(config:)
+    result = judge.call(system_prompt: "test", user_prompt: "test")
+
+    assert_in_delta 0.9, result["score"]
+    assert_equal 2, chat.call_count
+  end
+
+  def test_call_retries_connection_failures
+    chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}', fail_times: 1,
+                                     error_class: Faraday::ConnectionFailed)
     RubyLLMStub.fake_chat = chat
 
     config = RubricLLM::Config.new(max_retries: 2, retry_base_delay: 0.0)
@@ -115,7 +129,8 @@ class TestJudge < Minitest::Test
   end
 
   def test_call_raises_after_exhausting_retries
-    chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}', fail_times: 5)
+    chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}', fail_times: 5,
+                                     error_class: RubyLLMReal::RateLimitError)
     RubyLLMStub.fake_chat = chat
 
     config = RubricLLM::Config.new(max_retries: 2, retry_base_delay: 0.0)
@@ -130,10 +145,42 @@ class TestJudge < Minitest::Test
   end
 
   def test_call_no_retry_with_zero_max_retries
-    chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}', fail_times: 1)
+    chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}', fail_times: 1,
+                                     error_class: RubyLLMReal::ServerError)
     RubyLLMStub.fake_chat = chat
 
     config = RubricLLM::Config.new(max_retries: 0, retry_base_delay: 0.0)
+    judge = RubricLLM::Judge.new(config:)
+
+    assert_raises(RubricLLM::JudgeError) do
+      judge.call(system_prompt: "test", user_prompt: "test")
+    end
+
+    assert_equal 1, chat.call_count
+  end
+
+  def test_call_does_not_retry_authentication_failures
+    chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}', fail_times: 1,
+                                     error_class: RubyLLMReal::UnauthorizedError)
+    RubyLLMStub.fake_chat = chat
+
+    config = RubricLLM::Config.new(max_retries: 3, retry_base_delay: 0.0)
+    judge = RubricLLM::Judge.new(config:)
+
+    error = assert_raises(RubricLLM::JudgeError) do
+      judge.call(system_prompt: "test", user_prompt: "test")
+    end
+
+    assert_includes error.message, "transient failure"
+    assert_equal 1, chat.call_count
+  end
+
+  def test_call_does_not_retry_bad_request_failures
+    chat = RubyLLMStub::FakeChat.new(response_content: '{"score": 0.9}', fail_times: 1,
+                                     error_class: RubyLLMReal::ContextLengthExceededError)
+    RubyLLMStub.fake_chat = chat
+
+    config = RubricLLM::Config.new(max_retries: 3, retry_base_delay: 0.0)
     judge = RubricLLM::Judge.new(config:)
 
     assert_raises(RubricLLM::JudgeError) do

--- a/test/test_judge_contract.rb
+++ b/test/test_judge_contract.rb
@@ -47,17 +47,19 @@ class TestJudgeContract < Minitest::Test
     assert_equal 1, chat.call_count
   end
 
-  def test_call_retries_judge_contract_failures
+  # A contract violation is deterministic at the default temperature of 0.0,
+  # so retrying it only spends tokens to get the same bad response.
+  def test_call_does_not_retry_judge_contract_failures
     chat = RubyLLMStub::FakeChat.new(response_content: "This is not JSON")
     RubyLLMStub.fake_chat = chat
 
-    retrying_judge = RubricLLM::Judge.new(config: RubricLLM::Config.new(max_retries: 1, retry_base_delay: 0.0))
+    retrying_judge = RubricLLM::Judge.new(config: RubricLLM::Config.new(max_retries: 3, retry_base_delay: 0.0))
 
     assert_raises(RubricLLM::JudgeError) do
       retrying_judge.call(system_prompt: "test", user_prompt: "test")
     end
 
-    assert_equal 2, chat.call_count
+    assert_equal 1, chat.call_count
   end
 
   def test_call_raises_for_missing_score

--- a/test/test_rspec_matchers.rb
+++ b/test/test_rspec_matchers.rb
@@ -3,6 +3,16 @@
 require "test_helper"
 require "rubric_llm/rspec"
 
+# Stands in for a judge that produced no score, to check the matcher fails closed.
+class NilScoreHallucinationMatcher < RubricLLM::RSpecMatchers::HallucinationMatcher
+  private
+
+  def evaluate(*, **)
+    @result = { score: nil, details: { error: "judge unavailable" } }
+    nil
+  end
+end
+
 # Tests for RSpec matchers using Minitest (no rspec dependency needed).
 # Each matcher is a plain Ruby object with matches?, failure_message, etc.
 class TestRSpecMatchers < Minitest::Test
@@ -142,6 +152,34 @@ class TestRSpecMatchers < Minitest::Test
 
     assert matcher.matches?("answer")
     assert_equal custom, matcher.config
+  end
+
+  # --- Empty context is a caller error, not a quality verdict ---
+
+  def test_hallucination_matcher_rejects_empty_context
+    error = assert_raises(ArgumentError) do
+      RubricLLM::RSpecMatchers::HallucinationMatcher.new([])
+    end
+
+    assert_includes error.message, "non-empty"
+  end
+
+  def test_hallucination_matcher_rejects_blank_context
+    assert_raises(ArgumentError) do
+      RubricLLM::RSpecMatchers::HallucinationMatcher.new(["   ", ""])
+    end
+  end
+
+  def test_faithfulness_matcher_rejects_empty_context
+    assert_raises(ArgumentError) do
+      RubricLLM::RSpecMatchers::FaithfulnessMatcher.new([])
+    end
+  end
+
+  def test_hallucination_matcher_fails_closed_on_nil_score
+    matcher = NilScoreHallucinationMatcher.new(["context"])
+
+    refute matcher.matches?("answer"), "a missing score must not read as a detected hallucination"
   end
 
   # --- DSL helpers ---

--- a/test/test_rspec_matchers.rb
+++ b/test/test_rspec_matchers.rb
@@ -182,6 +182,13 @@ class TestRSpecMatchers < Minitest::Test
     refute matcher.matches?("answer"), "a missing score must not read as a detected hallucination"
   end
 
+  def test_hallucination_matcher_names_a_missing_score_in_its_failure_message
+    matcher = NilScoreHallucinationMatcher.new(["context"])
+    matcher.matches?("answer")
+
+    assert_includes matcher.failure_message, "got nil"
+  end
+
   # --- DSL helpers ---
 
   def test_dsl_helpers_exist

--- a/test/test_statistics.rb
+++ b/test/test_statistics.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestStatistics < Minitest::Test
+  Stats = RubricLLM::Statistics
+
+  # --- Paired t-test ---
+
+  def test_paired_t_test_returns_one_for_fewer_than_two_pairs
+    assert_in_delta 1.0, Stats.paired_t_test([0.5], [0.9])
+    assert_in_delta 1.0, Stats.paired_t_test([], [])
+  end
+
+  def test_paired_t_test_returns_one_when_every_difference_is_identical
+    assert_in_delta 1.0, Stats.paired_t_test([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+  end
+
+  def test_paired_t_test_matches_known_t_table_value
+    # diffs = [0.3, 0.25, 0.3], t = 17.0, df = 2
+    p_value = Stats.paired_t_test([0.5, 0.6, 0.7], [0.8, 0.85, 1.0])
+
+    assert_in_delta 0.003442, p_value, 1e-5
+  end
+
+  def test_paired_t_test_is_symmetric_in_magnitude
+    forward = Stats.paired_t_test([0.5, 0.6, 0.7], [0.8, 0.85, 1.0])
+    reverse = Stats.paired_t_test([0.8, 0.85, 1.0], [0.5, 0.6, 0.7])
+
+    assert_in_delta forward, reverse, 1e-12
+  end
+
+  # --- Two-tailed p ---
+
+  def test_two_tailed_p_handles_values_close_to_one
+    p_value = Stats.two_tailed_p(0.02105086415353341, 72)
+
+    assert_in_delta 0.9832633107858819, p_value, 1e-9
+  end
+
+  def test_two_tailed_p_matches_t_table_at_the_five_percent_boundary
+    # Critical t for df = 2 at alpha = 0.05 is 4.302653
+    assert_in_delta 0.05, Stats.two_tailed_p(4.302653, 2), 1e-6
+  end
+
+  def test_two_tailed_p_does_not_swallow_unexpected_errors
+    buggy = Stats.dup
+    original_verbose = $VERBOSE
+    $VERBOSE = nil
+    buggy.define_singleton_method(:regularized_beta) { |*| raise "continued fraction bug" }
+    $VERBOSE = original_verbose
+
+    assert_raises(RuntimeError) { buggy.two_tailed_p(1.0, 5) }
+  end
+
+  # --- Holm-Bonferroni ---
+
+  def test_holm_adjust_scales_the_smallest_p_value_by_the_count
+    adjusted = Stats.holm_adjust([0.01, 1.0])
+
+    assert_in_delta 0.02, adjusted[0], 1e-12
+    assert_in_delta 1.0, adjusted[1], 1e-12
+  end
+
+  def test_holm_adjust_preserves_input_order
+    adjusted = Stats.holm_adjust([1.0, 0.01])
+
+    assert_in_delta 1.0, adjusted[0], 1e-12
+    assert_in_delta 0.02, adjusted[1], 1e-12
+  end
+
+  def test_holm_adjust_is_monotonic_and_never_below_the_raw_value
+    raw = [0.04, 0.005, 0.02, 0.9]
+    adjusted = Stats.holm_adjust(raw)
+
+    raw.each_with_index { |p_value, i| assert_operator adjusted[i], :>=, p_value }
+
+    by_raw_rank = raw.each_index.sort_by { |i| raw[i] }
+    in_rank_order = by_raw_rank.map { |i| adjusted[i] }
+
+    assert_equal adjusted.sort, in_rank_order
+  end
+
+  def test_holm_adjust_caps_at_one
+    Stats.holm_adjust([0.6, 0.7, 0.8]).each do |p_value|
+      assert_operator p_value, :<=, 1.0
+    end
+  end
+
+  def test_holm_adjust_handles_an_empty_list
+    assert_empty Stats.holm_adjust([])
+  end
+end


### PR DESCRIPTION
Five defects caused the gem to report verdicts no judge produced, plus one numerical bug found while testing the fix. Targets release 0.5.0.

## Fixes

**Hallucination matcher failed open.** `HallucinationMatcher#matches?` used `score.nil? || score < threshold`, so a judge failure counted as a hallucination and failed the build with a false positive. Now `!score.nil? && score < threshold`.

**Blank context produced a score.** An empty or whitespace-only context reached the judge as an empty prompt. `assert_faithful`, `refute_hallucination`, `be_faithful`, and `hallucinate` now raise `ArgumentError`. `ContextPrecision` and `ContextRecall` use the same `Metrics::Base.normalize_context` as `Faithfulness` and return `No context provided` when nothing usable remains.

**Every error was retried.** `Judge#call` rescued `StandardError`. A bad API key, an exhausted quota, or an over-long prompt slept through the full retry schedule before failing, which on a 100-sample batch is measured in minutes per sample. Retries are now limited to `RubyLLM::RateLimitError`, `ServerError`, `ServiceUnavailableError`, and `OverloadedError`. Transport timeouts and connection resets are left to RubyLLM's connection, which already retries them. Judge contract violations are deterministic at the default temperature of 0.0, so retrying them only spends tokens for the same bad response. Non-transient errors are still wrapped in `JudgeError`, so `Evaluator`'s rescue contract holds and a bad key yields an all-nil report immediately.

**Comparison paired by array position.** Two reports built from the same dataset in a different order gave an invalid paired t-test with no warning. Pairing is now keyed on `sample[:question]`. Questions present in only one report are dropped with a warning, as are uneven repeats.

**No multiple-comparison correction.** Each metric ran an independent t-test at alpha 0.05. Six metrics give a family-wise false-positive rate near 26%. Results now carry `p_value_adjusted` from a Holm-Bonferroni step-down alongside the raw `p_value`. `summary` prints a `p-adj` column, and `significant_improvements` and `significant_regressions` test the adjusted value.

**Float-zero variance guard.** `paired_t_test` returned early on `se.zero?`. A constant difference of +0.3 across `[0.1, 0.2, 0.3]` and `[0.4, 0.5, 0.6]` gives diffs of `[0.30000000000000004, 0.3, 0.30000000000000004]`, so `var_d` is about `5.7e-33`, `se` is nonzero, and the function returned a p-value near zero: a spurious significant result. The guard now scales with the data.

Also narrowed `two_tailed_p` to rescue only `Math::DomainError`, `ZeroDivisionError`, and `FloatDomainError` instead of swallowing every `StandardError` as 1.0.

## Structure

Extracts `RubricLLM::Statistics` (paired t-test, two-tailed p, Holm adjustment, incomplete beta). No LLM calls, no state, independently testable. This also resolves the `Metrics/ClassLength` offense `Comparison` picked up from the pairing logic.

No new dependencies. RubyLLM's connection already retries transport failures through faraday-retry, so `Judge` does not name Faraday's error classes and does not depend on faraday.

The two retry layers still overlap for the `RubyLLM::*` errors. Collapsing them changes what `max_retries` and `retry_base_delay` mean, so that is tracked separately in #12.

## Breaking changes

- `be_faithful` and `hallucinate` with an empty context raise `ArgumentError` instead of returning a verdict.
- Significance markers and both `significant_*` methods read the adjusted p-value, so a metric that was marked significant under the old raw comparison may no longer be.
- `summary` output gained a `p-adj` column and a trailing note.

## Verification

`bundle exec rake`: 168 runs, 400 assertions, 0 failures, 0 errors. RuboCop clean on 47 files.

New tests cover fail-closed nil scores, blank-context rejection in both frameworks, retry and no-retry paths per error class, pairing under reordering and under missing or repeated questions, and the Holm adjustment (scaling, order preservation, monotonicity, capping at 1.0).

